### PR TITLE
change pstate 16 to pstate 0

### DIFF
--- a/airootfs/home/tori/.local/share/tori/patches/0000-llamacpp-server-drop-pstate-in-idle.patch
+++ b/airootfs/home/tori/.local/share/tori/patches/0000-llamacpp-server-drop-pstate-in-idle.patch
@@ -4,7 +4,7 @@
              {"id_task", slot.id_task},
          });
  
-+        system("nvidia-pstate -s -ps 16");
++        system("nvidia-pstate -s -ps 0");
          return true;
      }
  


### PR DESCRIPTION
The llama.cpp patch tries to set the GPUs to high performance mode when beginning inference. However, it currently has the pstate values backwards, and is using 16 (the lowest) as if it were the highest. This actually works fine on my machine, at least, since `nvidia-pstate -ps 16` successfully forces pstate to... 0. For some reason. But might as well specify the right value in case that gets fixed.